### PR TITLE
Add support for multibyte characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-export { getEmbeddingLevels } from './embeddingLevels.js'
-export { getReorderSegments, getReorderedIndices, getReorderedString } from './reordering.js'
+export { getEmbeddingLevels, getEmbeddingLevelsForCharacters } from './embeddingLevels.js'
+export { getReorderSegments, getReorderedCharacters, getReorderedIndices, getReorderedString } from './reordering.js'
 export { getBidiCharType, getBidiCharTypeName } from './charTypes.js'
 export { getMirroredCharacter, getMirroredCharactersMap } from './mirroring.js'
 export { closingToOpeningBracket, openingToClosingBracket, getCanonicalBracket } from './brackets.js'
+export { stringToArray } from './util/stringToArray.js'

--- a/src/mirroring.js
+++ b/src/mirroring.js
@@ -22,23 +22,23 @@ export function getMirroredCharacter (char) {
 }
 
 /**
- * Given a string and its resolved embedding levels, build a map of indices to replacement chars
+ * Given a character array and its resolved embedding levels, build a map of indices to replacement chars
  * for any characters in right-to-left segments that have defined mirrored characters.
- * @param string
+ * @param {string[]} characters - an array of character strings
  * @param embeddingLevels
  * @param [start]
  * @param [end]
  * @return {Map<number, string>}
  */
-export function getMirroredCharactersMap(string, embeddingLevels, start, end) {
-  let strLen = string.length
+export function getMirroredCharactersMap(characters, embeddingLevels, start, end) {
+  let strLen = characters.length
   start = Math.max(0, start == null ? 0 : +start)
   end = Math.min(strLen - 1, end == null ? strLen - 1 : +end)
 
   const map = new Map()
   for (let i = start; i <= end; i++) {
     if (embeddingLevels[i] & 1) { //only odd (rtl) levels
-      const mirror = getMirroredCharacter(string[i])
+      const mirror = getMirroredCharacter(characters[i])
       if (mirror !== null) {
         map.set(i, mirror)
       }

--- a/src/reordering.js
+++ b/src/reordering.js
@@ -1,17 +1,18 @@
 import { getBidiCharType, TRAILING_TYPES } from './charTypes.js'
 import { getMirroredCharacter } from './mirroring.js'
+import { stringToArray } from './utils/stringToArray.js'
 
 /**
  * Given a start and end denoting a single line within a string, and a set of precalculated
  * bidi embedding levels, produce a list of segments whose ordering should be flipped, in sequence.
- * @param {string} string - the full input string
+ * @param {string[]} characters - an array of character strings
  * @param {GetEmbeddingLevelsResult} embeddingLevelsResult - the result object from getEmbeddingLevels
- * @param {number} [start] - first character in a subset of the full string
- * @param {number} [end] - last character in a subset of the full string
+ * @param {number} [start] - first character in a subset of the full characters array
+ * @param {number} [end] - last character in a subset of the full characters array
  * @return {number[][]} - the list of start/end segments that should be flipped, in order.
  */
-export function getReorderSegments(string, embeddingLevelsResult, start, end) {
-  let strLen = string.length
+export function getReorderSegments(characters, embeddingLevelsResult, start, end) {
+  let strLen = characters.length
   start = Math.max(0, start == null ? 0 : +start)
   end = Math.min(strLen - 1, end == null ? strLen - 1 : +end)
 
@@ -25,7 +26,7 @@ export function getReorderSegments(string, embeddingLevelsResult, start, end) {
 
       // 3.4 L1.4: Reset any sequence of whitespace characters and/or isolate formatting characters at the
       // end of the line to the paragraph level.
-      for (let i = lineEnd; i >= lineStart && (getBidiCharType(string[i]) & TRAILING_TYPES); i--) {
+      for (let i = lineEnd; i >= lineStart && (getBidiCharType(characters[i]) & TRAILING_TYPES); i--) {
         lineLevels[i] = paragraph.level
       }
 
@@ -57,21 +58,21 @@ export function getReorderSegments(string, embeddingLevelsResult, start, end) {
 }
 
 /**
- * @param {string} string
+ * @param {array} characters
  * @param {GetEmbeddingLevelsResult} embedLevelsResult
  * @param {number} [start]
  * @param {number} [end]
- * @return {string} the new string with bidi segments reordered
+ * @return {array} a new array with bidi segments reordered
  */
-export function getReorderedString(string, embedLevelsResult, start, end) {
-  const indices = getReorderedIndices(string, embedLevelsResult, start, end)
-  const chars = [...string]
+export function getReorderedCharacters(characters, embedLevelsResult, start, end) {
+  const indices = getReorderedIndices(characters, embedLevelsResult, start, end)
+  let result = [];
   indices.forEach((charIndex, i) => {
-    chars[i] = (
-      (embedLevelsResult.levels[charIndex] & 1) ? getMirroredCharacter(string[charIndex]) : null
-    ) || string[charIndex]
+    result[i] = (
+      (embedLevelsResult.levels[charIndex] & 1) ? getMirroredCharacter(characters[charIndex]) : null
+    ) || characters[charIndex]
   })
-  return chars.join('')
+  return result
 }
 
 /**
@@ -79,13 +80,24 @@ export function getReorderedString(string, embedLevelsResult, start, end) {
  * @param {GetEmbeddingLevelsResult} embedLevelsResult
  * @param {number} [start]
  * @param {number} [end]
+ * @return {string} the new string with bidi segments reordered
+ */
+export function getReorderedString(string, embedLevelsResult, start, end) {
+  return getReorderedCharacters(stringToArray(string), embedLevelsResult, start, end).join('')
+}
+
+/**
+ * @param {string[]} characters - an array of character strings
+ * @param {GetEmbeddingLevelsResult} embedLevelsResult
+ * @param {number} [start]
+ * @param {number} [end]
  * @return {number[]} an array with character indices in their new bidi order
  */
-export function getReorderedIndices(string, embedLevelsResult, start, end) {
-  const segments = getReorderSegments(string, embedLevelsResult, start, end)
+export function getReorderedIndices(characters, embedLevelsResult, start, end) {
+  const segments = getReorderSegments(characters, embedLevelsResult, start, end)
   // Fill an array with indices
   const indices = []
-  for (let i = 0; i < string.length; i++) {
+  for (let i = 0; i < characters.length; i++) {
     indices[i] = i
   }
   // Reverse each segment in order

--- a/src/reordering.js
+++ b/src/reordering.js
@@ -1,6 +1,6 @@
 import { getBidiCharType, TRAILING_TYPES } from './charTypes.js'
 import { getMirroredCharacter } from './mirroring.js'
-import { stringToArray } from './utils/stringToArray.js'
+import { stringToArray } from './util/stringToArray.js'
 
 /**
  * Given a start and end denoting a single line within a string, and a set of precalculated

--- a/src/util/stringToArray.js
+++ b/src/util/stringToArray.js
@@ -1,0 +1,10 @@
+/**
+ * Break a string into rendered characters (graphemes), 
+ * using simpler methods of breaking strings apart doesn't take into account characters with multiple bytes.
+ * For instance `'👱🏽‍♂️'.length === 7`
+ * @param {string} string - input string
+ * @return {string[]} - the string broken down into an array of characters.
+ */
+export function stringToArray (string) {
+  return [...new Intl.Segmenter().segment(string)].map(x => x.segment);
+}

--- a/test/BidiCharacterTest.js
+++ b/test/BidiCharacterTest.js
@@ -30,9 +30,11 @@ module.exports.runBidiCharacterTest = function (bidi) {
       expectedOrder = expectedOrder.split(' ').map(s => parseInt(s, 10))
 
       const start = performance.now()
-      const embedLevelsResult = bidi.getEmbeddingLevels(input, paraDir)
+      const characters = bidi.stringToArray(input)
+      const embedLevelsResult = bidi.getEmbeddingLevelsForCharacters(characters.slice(), paraDir)
       const {levels, paragraphs} = embedLevelsResult
-      let reordered = bidi.getReorderedIndices(input, embedLevelsResult)
+      let reordered = bidi.getReorderedIndices(characters.slice(), embedLevelsResult)
+
       totalTime += performance.now() - start
 
       reordered = reordered.filter(i => expectedLevels[i] !== 'x') //those with indeterminate level are ommitted

--- a/test/BidiTest.js
+++ b/test/BidiTest.js
@@ -72,9 +72,10 @@ module.exports.runBidiTest = function (bidi) {
         if (testFilter && testFilter(lineIdx + 1, paraDir) === false) continue
 
         const start = performance.now()
-        const embedLevelsResult = bidi.getEmbeddingLevels(inputString, paraDir)
+        const characters = inputString.split(''); //bidi.stringToArray(inputString)
+        const embedLevelsResult = bidi.getEmbeddingLevelsForCharacters(characters.slice(), paraDir)
         const {levels, paragraphs} = embedLevelsResult
-        let reordered = bidi.getReorderedIndices(inputString, embedLevelsResult)
+        let reordered = bidi.getReorderedIndices(characters.slice(), embedLevelsResult)
         totalTime += performance.now() - start
         reordered = reordered.filter(i => expectedLevels[i] !== 'x') //those with indeterminate level are ommitted
 


### PR DESCRIPTION
All functions now operate based on character arrays rather than indexing characters from within the string.
The reason why this is important is `'👱🏽‍♂️'.length` is 7 not 1 so accessing string[0] through string[6] would be modifying the bytes in the middle of this single character which also messed with your logic related to how reordering should work.

This seems to fix https://github.com/lojjic/bidi-js/issues/9 
but the problem can be seen more clearly in this modified version of their example where I changed their emoji to the one above. https://codepen.io/talltyler/pen/jOomxwz

To get this working I'm using Intl.Segmenter which is newish but has pretty good support across browsers along with Node 16 and Deno. 
https://caniuse.com/mdn-javascript_builtins_intl_segmenter
If you would rather use something that is more compatible with older environments I can make a change but the only other way I know how to do it is with a huge regex that covers all of the ranges that can connect.

I tried to modify the comments and keep the current api working but if you are ok changing this a few of these functions can be removed.