### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A JavaScript implementation of the Unicode Bidirectional Algorithm",
   "main": "dist/bidi.js",
   "module": "dist/bidi.mjs",
+  "types": "src/bidi.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/lojjic/bidi-js.git"

--- a/src/bidi.d.ts
+++ b/src/bidi.d.ts
@@ -1,0 +1,190 @@
+// Type definitions for bidi-js
+// A JavaScript implementation of the Unicode Bidirectional Algorithm
+
+/**
+ * One of the 23 Unicode bidirectional character type names, as returned by
+ * {@link Bidi.getBidiCharTypeName}.
+ */
+export type BidiCharTypeName =
+  | "L"
+  | "R"
+  | "EN"
+  | "ES"
+  | "ET"
+  | "AN"
+  | "CS"
+  | "B"
+  | "S"
+  | "WS"
+  | "ON"
+  | "BN"
+  | "NSM"
+  | "AL"
+  | "LRO"
+  | "RLO"
+  | "LRE"
+  | "RLE"
+  | "PDF"
+  | "LRI"
+  | "RLI"
+  | "FSI"
+  | "PDI";
+
+/**
+ * The resolved embedding levels for a string, as returned by
+ * {@link Bidi.getEmbeddingLevels}.
+ */
+export interface EmbeddingLevels {
+  /**
+   * A `Uint8Array` holding the calculated bidi embedding level for each
+   * character in the string. A character is in a right-to-left scope if its
+   * level is an odd number, and left-to-right if it's even.
+   */
+  levels: Uint8Array;
+  /**
+   * One entry per paragraph in the text (paragraphs are separated by explicit
+   * breaking characters, not soft line wrapping). The `start` and `end` indices
+   * are inclusive, and `level` is the resolved base embedding level of that
+   * paragraph.
+   */
+  paragraphs: Array<{ start: number; end: number; level: number }>;
+}
+
+/**
+ * A `bidi` object exposing the methods for bidi processing, as returned by the
+ * default-exported factory function.
+ */
+export interface Bidi {
+  /**
+   * Apply the Bidirectional Algorithm to a string, returning the resolved
+   * embedding levels plus a list of each paragraph's start/end indices and
+   * resolved base embedding level.
+   *
+   * @param string - The input string containing mixed-direction text.
+   * @param baseDirection - Use `"ltr"` or `"rtl"` to force a base paragraph
+   *   direction, otherwise a direction will be chosen automatically from each
+   *   paragraph's contents.
+   */
+  getEmbeddingLevels(
+    string: string,
+    baseDirection?: "ltr" | "rtl" | "auto"
+  ): EmbeddingLevels;
+
+  /**
+   * Given a start and end denoting a single line within a string, and a set of
+   * precalculated bidi embedding levels, produce a list of `[start, end]`
+   * segments whose ordering should be flipped, in sequence.
+   *
+   * @param string - The full input string.
+   * @param embeddingLevelsResult - The result object from
+   *   {@link Bidi.getEmbeddingLevels}.
+   * @param start - First character in a subset of the full string (inclusive).
+   * @param end - Last character in a subset of the full string (inclusive).
+   * @returns The list of start/end segments that should be flipped, in order.
+   */
+  getReorderSegments(
+    string: string,
+    embeddingLevelsResult: EmbeddingLevels,
+    start?: number,
+    end?: number
+  ): number[][];
+
+  /**
+   * Given a string and its resolved embedding levels, return an array of
+   * character indices in their new bidi order.
+   *
+   * @param string - The full input string.
+   * @param embedLevelsResult - The result object from
+   *   {@link Bidi.getEmbeddingLevels}.
+   * @param start - First character in a subset of the full string (inclusive).
+   * @param end - Last character in a subset of the full string (inclusive).
+   */
+  getReorderedIndices(
+    string: string,
+    embedLevelsResult: EmbeddingLevels,
+    start?: number,
+    end?: number
+  ): number[];
+
+  /**
+   * Given a string and its resolved embedding levels, return a new string with
+   * its bidi segments reordered (and right-to-left mirrored characters
+   * swapped).
+   *
+   * @param string - The full input string.
+   * @param embedLevelsResult - The result object from
+   *   {@link Bidi.getEmbeddingLevels}.
+   * @param start - First character in a subset of the full string (inclusive).
+   * @param end - Last character in a subset of the full string (inclusive).
+   */
+  getReorderedString(
+    string: string,
+    embedLevelsResult: EmbeddingLevels,
+    start?: number,
+    end?: number
+  ): string;
+
+  /**
+   * Get the bidi character type bit flag for a given character.
+   */
+  getBidiCharType(char: string): number;
+
+  /**
+   * Get the bidi character type name for a given character.
+   */
+  getBidiCharTypeName(char: string): BidiCharTypeName;
+
+  /**
+   * Get the mirrored character for a given character, if one exists, otherwise
+   * `null`. Only meaningful for right-to-left characters (those whose embedding
+   * level is an odd number).
+   */
+  getMirroredCharacter(char: string): string | null;
+
+  /**
+   * Given a string and its resolved embedding levels, build a map of indices to
+   * replacement characters for any characters in right-to-left segments that
+   * have defined mirrored characters.
+   *
+   * @param string - The full input string.
+   * @param embeddingLevels - The `levels` array from
+   *   {@link Bidi.getEmbeddingLevels}.
+   * @param start - First character in a subset of the full string (inclusive).
+   * @param end - Last character in a subset of the full string (inclusive).
+   */
+  getMirroredCharactersMap(
+    string: string,
+    embeddingLevels: Uint8Array,
+    start?: number,
+    end?: number
+  ): Map<number, string>;
+
+  /**
+   * Get the opening bracket character corresponding to a given closing bracket
+   * character, or `null` if there is none.
+   */
+  closingToOpeningBracket(char: string): string | null;
+
+  /**
+   * Get the closing bracket character corresponding to a given opening bracket
+   * character, or `null` if there is none.
+   */
+  openingToClosingBracket(char: string): string | null;
+
+  /**
+   * Retrieve the canonical form of a bracket character, or `null` if there is
+   * none.
+   */
+  getCanonicalBracket(char: string): string | null;
+}
+
+/**
+ * The `bidi-js` package's only export is this factory function, which you
+ * _must invoke_ to return a `bidi` object exposing the methods for bidi
+ * processing.
+ *
+ * The factory exists so the entire module's code is wrapped within a single
+ * self-contained function with no closure dependencies, which enables that
+ * function to be stringified and passed into a web worker.
+ */
+export default function bidiFactory(): Bidi;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -14,16 +14,31 @@ function parse () {
   }
 }
 
+/**
+ * Get the opening bracket character corresponding to a given closing bracket character.
+ * @param {string} char
+ * @returns {string | null}
+ */
 export function openingToClosingBracket (char) {
   parse()
   return openToClose.get(char) || null
 }
 
+/**
+ * Get the closing bracket character corresponding to a given opening bracket character.
+ * @param {string} char
+ * @returns {string | null}
+ */
 export function closingToOpeningBracket (char) {
   parse()
   return closeToOpen.get(char) || null
 }
 
+/**
+ * Retrieves the canonical form of a bracket character.
+ * @param {string} char
+ * @returns {string | null}
+ */
 export function getCanonicalBracket (char) {
   parse()
   return canonical.get(char) || null

--- a/src/charTypes.js
+++ b/src/charTypes.js
@@ -70,6 +70,11 @@ function getBidiCharType (char) {
   return map.get(char.codePointAt(0)) || TYPES.L
 }
 
+/**
+ * Get Bidi Character Type Name
+ * @param {string} char
+ * @returns { "L" | "R" | "EN" | "ES" | "ET" | "AN" | "CS" | "B" | "S" | "WS" | "ON" | "BN" | "NSM" | "AL" | "LRO" | "RLO" | "LRE" | "RLE" | "PDF" | "LRI" | "RLI" | "FSI" | "PDI" }
+ */
 function getBidiCharTypeName(char) {
   return TYPES_TO_NAMES[getBidiCharType(char)]
 }

--- a/src/embeddingLevels.js
+++ b/src/embeddingLevels.js
@@ -37,7 +37,7 @@ const {
 
 /**
  * @typedef {object} GetEmbeddingLevelsResult
- * @property {{start, end, level}[]} paragraphs
+ * @property {{start: number, end: number, level: number}[]} paragraphs
  * @property {Uint8Array} levels
  */
 

--- a/src/mirroring.js
+++ b/src/mirroring.js
@@ -16,6 +16,11 @@ function parse () {
   }
 }
 
+/**
+ * Get the mirrored character for a given character, if one exists.
+ * @param {string} char
+ * @return {string|null}
+ */
 export function getMirroredCharacter (char) {
   parse()
   return mirrorMap.get(char) || null
@@ -24,10 +29,10 @@ export function getMirroredCharacter (char) {
 /**
  * Given a string and its resolved embedding levels, build a map of indices to replacement chars
  * for any characters in right-to-left segments that have defined mirrored characters.
- * @param string
- * @param embeddingLevels
- * @param [start]
- * @param [end]
+ * @param {string} string
+ * @param {Uint8Array} embeddingLevels
+ * @param {number?} [start]
+ * @param {number?} [end]
  * @return {Map<number, string>}
  */
 export function getMirroredCharactersMap(string, embeddingLevels, start, end) {


### PR DESCRIPTION
Adds TypeScript types for `bidi-js`, resolving #11.

This builds on @yasarsid's work in #12 (he's credited as co-author) and addresses the review feedback there. It is scoped to **types only** per the request in that thread.

## What's here

- **`src/bidi.d.ts`** — a hand-maintained declaration file that correctly types the default-exported `bidiFactory()` and the `bidi` object it returns (all 11 methods), plus the `EmbeddingLevels` and `BidiCharTypeName` types.
- **`package.json`** — a single `"types": "src/bidi.d.ts"` entry (published via the existing `/src` `files` entry, so no packaging changes).
- **JSDoc improvements** on the source functions.

Nothing else changed: no version bump, no dependency changes, no test changes, no build changes.

## Why hand-written instead of generated

The discussion in #12 found that autogenerating the `.d.ts` via `tsc` produces incorrect types: the build wraps the whole module in a stringified IIFE factory (so it can be passed to a web worker), and `tsc` emits the methods as static namespace members on the `bidiFactory` function rather than members of its **return type**. The result declares `bidiFactory(): {}` — useless to consumers. This isn't fixable from JSDoc because tsc can't see the runtime return shape.

Per the suggestion in the review (_"I'd also be fine with a static .d.ts file in the sources that's manually maintained"_), this PR takes that route. The file models the public API exactly as documented in the README.

## Validation

Type-checked the declarations against README-style consumer usage under `strict` mode — all usages resolve on the factory's return value, and `bidiFactory.getEmbeddingLevels` (the static-member bug) is correctly rejected. Full test suite (`npm test`, 770k + 91k assertions) passes.

```ts
import bidiFactory from 'bidi-js'
const bidi = bidiFactory()
const { levels, paragraphs } = bidi.getEmbeddingLevels(text, 'rtl') // fully typed
```